### PR TITLE
feat(portal): onboarding-flyt og roll-baserte landingssider (GUIDE-1 + GUIDE-4)

### DIFF
--- a/dataportal/auth.py
+++ b/dataportal/auth.py
@@ -47,6 +47,9 @@ def _db():
         conn.close()
 
 
+PERSONAS = ("analyst", "engineer", "domain_owner")
+
+
 def init_db() -> None:
     with _db() as conn:
         conn.executescript("""
@@ -126,6 +129,13 @@ def init_db() -> None:
             CREATE INDEX IF NOT EXISTS idx_usage_product ON usage_events(product_id);
             CREATE INDEX IF NOT EXISTS idx_usage_ts ON usage_events(ts);
         """)
+        # GUIDE-1/4: legg til persona og onboarding-felter (idempotent migrasjon)
+        existing_cols = {r[1] for r in conn.execute("PRAGMA table_info(users)").fetchall()}
+        if "persona" not in existing_cols:
+            conn.execute("ALTER TABLE users ADD COLUMN persona TEXT")
+        if "onboarding_completed_at" not in existing_cols:
+            conn.execute("ALTER TABLE users ADD COLUMN onboarding_completed_at TEXT")
+
         # Opprett admin-bruker hvis ingen finnes
         row = conn.execute("SELECT COUNT(*) FROM users").fetchone()
         if row[0] == 0:
@@ -398,7 +408,21 @@ def get_current_user(request) -> Optional[dict]:
     payload = decode_access_token(token)
     if not payload:
         return None
-    return {"id": payload["sub"], "username": payload["username"], "role": payload["role"]}
+    user = {"id": payload["sub"], "username": payload["username"], "role": payload["role"]}
+    # Slå opp persona og onboarding-status fra DB (bestemmer landingssidens innhold).
+    try:
+        with _db() as conn:
+            row = conn.execute(
+                "SELECT persona, onboarding_completed_at FROM users WHERE id = ?",
+                (payload["sub"],),
+            ).fetchone()
+            if row:
+                user["persona"] = row["persona"]
+                user["onboarding_completed_at"] = row["onboarding_completed_at"]
+    except Exception:
+        user["persona"] = None
+        user["onboarding_completed_at"] = None
+    return user
 
 # ── domeneprivilegier ──────────────────────────────────────────────────────────
 
@@ -539,3 +563,113 @@ def update_incident(incident_id: str, status: str, updated_by: str) -> dict | No
             (status, now, updated_by, resolved_at, incident_id),
         )
         return dict(conn.execute("SELECT * FROM incidents WHERE id = ?", (incident_id,)).fetchone())
+
+
+# ── GUIDE-1/4: persona og onboarding ────────────────────────────────────────────
+
+# Onboarding-steg som vises på /getting-started. `predicate` evaluerer mot
+# eksisterende data i databasen — vi unngår å duplisere state.
+ONBOARDING_STEPS = [
+    {
+        "key":         "set_persona",
+        "title":       "Velg din rolle",
+        "description": "Tilpass forsiden basert på om du er analytiker, dataingeniør eller domeneeier.",
+        "url":         "/getting-started?focus=persona",
+    },
+    {
+        "key":         "view_product",
+        "title":       "Åpne et dataprodukt",
+        "description": "Klikk inn på et produkt fra katalogen for å se schema, lineage og kvalitet.",
+        "url":         "/",
+    },
+    {
+        "key":         "open_glossary",
+        "title":       "Bli kjent med plattformkonseptene",
+        "description": "Bla i glossaret for forklaring av Medallion, Data Mesh, IDP og mer.",
+        "url":         "/glossary",
+    },
+    {
+        "key":         "subscribe",
+        "title":       "Abonner på et produkt",
+        "description": "Få varsel når et produkt får schema- eller SLO-endringer.",
+        "url":         "/",
+    },
+    {
+        "key":         "generate_notebook",
+        "title":       "Generer en notebook",
+        "description": "Lag et utgangspunkt for analyse i Jupyter via «Åpne i Jupyter».",
+        "url":         "/",
+    },
+]
+
+
+def set_persona(user_id: str, persona: str) -> bool:
+    if persona not in PERSONAS:
+        return False
+    with _db() as conn:
+        conn.execute("UPDATE users SET persona = ? WHERE id = ?", (persona, user_id))
+    return True
+
+
+def get_persona(user_id: str) -> str | None:
+    with _db() as conn:
+        row = conn.execute("SELECT persona FROM users WHERE id = ?", (user_id,)).fetchone()
+    return (row["persona"] if row else None) or None
+
+
+def get_onboarding_progress(user_id: str) -> dict:
+    """Returnér {step_key: bool} basert på state i databasen.
+
+    Stegene er fullført hvis:
+      set_persona       — users.persona er satt
+      view_product      — minst én usage_events.action='view' for brukeren
+      open_glossary     — minst én usage_events.action='view_glossary'
+      subscribe         — minst én rad i subscriptions
+      generate_notebook — minst én usage_events.action='generate_notebook'
+    """
+    with _db() as conn:
+        user_row = conn.execute(
+            "SELECT persona, onboarding_completed_at FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        if not user_row:
+            return {s["key"]: False for s in ONBOARDING_STEPS}
+
+        persona = user_row["persona"]
+
+        def _has_event(action: str) -> bool:
+            row = conn.execute(
+                "SELECT 1 FROM usage_events WHERE user_id = ? AND action = ? LIMIT 1",
+                (user_id, action),
+            ).fetchone()
+            return bool(row)
+
+        sub_row = conn.execute(
+            "SELECT 1 FROM subscriptions WHERE user_id = ? LIMIT 1", (user_id,)
+        ).fetchone()
+
+        return {
+            "set_persona":       bool(persona),
+            "view_product":      _has_event("view"),
+            "open_glossary":     _has_event("view_glossary"),
+            "subscribe":         bool(sub_row),
+            "generate_notebook": _has_event("generate_notebook"),
+        }
+
+
+def mark_onboarding_completed(user_id: str) -> None:
+    """Skriver tidsstempel — UI kan bruke dette til å skjule velkomstmodal."""
+    now = datetime.now(tz=timezone.utc).isoformat()
+    with _db() as conn:
+        conn.execute(
+            "UPDATE users SET onboarding_completed_at = ? WHERE id = ?",
+            (now, user_id),
+        )
+
+
+def is_onboarding_completed(user_id: str) -> bool:
+    with _db() as conn:
+        row = conn.execute(
+            "SELECT onboarding_completed_at FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+    return bool(row and row["onboarding_completed_at"])

--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -2341,6 +2341,8 @@ def api_generate_notebook(product_id: str, request: Request, force: bool = False
     pathlib.Path(NOTEBOOKS_DIR).mkdir(parents=True, exist_ok=True)
     nb_path.write_text(json.dumps(nb, ensure_ascii=False, indent=1))
     _push_to_jupyter(filename, nb)
+    if user:
+        auth.track_usage(product_id, "generate_notebook", user["id"])
 
     return {"filename": filename, "url": _jupyter_open_url(filename), "created": True}
 
@@ -3636,6 +3638,13 @@ def page_catalog(request: Request):
         if a and a.get("has_anomaly"):
             anomaly_map[m["id"]] = True
     view_counts = {r["product_id"]: r["views"] for r in auth.get_usage_counts(30)}
+
+    # GUIDE-4: rolle-tilpassede landings­widgets — påvirkes av ?persona=… for toggle.
+    persona  = (request.query_params.get("persona") or (user or {}).get("persona") or "analyst")
+    if persona not in auth.PERSONAS:
+        persona = "analyst"
+    persona_widgets = _persona_landing(persona, user, products, view_counts)
+
     return templates.TemplateResponse("catalog.html", _template_ctx(
         request,
         products=products,
@@ -3643,7 +3652,99 @@ def page_catalog(request: Request):
         all_tags=all_tags,
         anomaly_map=anomaly_map,
         view_counts=view_counts,
+        persona=persona,
+        persona_widgets=persona_widgets,
     ))
+
+
+def _persona_landing(persona: str, user: dict | None, products: list[dict], view_counts: dict) -> dict:
+    """Bygger rolle-spesifikke widget-data for forsiden (GUIDE-4)."""
+    user_domains = set(auth.get_user_domains(user["id"])) if user else set()
+    if persona == "engineer":
+        # Pipeline-bygger fokus: vis produkter med dag_id og deres siste pipeline-status
+        with_dag = [p for p in products if p.get("dag_id")]
+        return {
+            "title":    "Pipeline-bygger",
+            "subtitle": "Du ser dataingeniør-vista — fokus på pipelines, status og publisering.",
+            "shortcuts": [
+                {"label": "Pipeline-bygger", "url": "/pipeline-builder", "icon": "bi-tools"},
+                {"label": "DAG-status",       "url": "/pipelines",       "icon": "bi-diagram-3"},
+                {"label": "Publisér produkt", "url": "/publish",         "icon": "bi-cloud-upload"},
+            ],
+            "section_title":    "Produkter med pipeline",
+            "section_products": with_dag[:8],
+        }
+    if persona == "domain_owner":
+        # Eier-fokus: produkter du eier eller domeneprivilegier dekker
+        owned = [
+            p for p in products
+            if (user and p.get("owner") == user.get("username"))
+            or (p.get("domain") in user_domains)
+        ]
+        return {
+            "title":    "Domene­oversikt",
+            "subtitle": "Du ser domeneeier-vista — fokus på governance, SLA og abonnementer.",
+            "shortcuts": [
+                {"label": "Governance",  "url": "/governance",   "icon": "bi-shield-lock"},
+                {"label": "Observability","url": "/observability", "icon": "bi-graph-up"},
+                {"label": "Publisér produkt", "url": "/publish",  "icon": "bi-cloud-upload"},
+            ],
+            "section_title":    "Mine produkter",
+            "section_products": owned[:8],
+        }
+    # analyst (default)
+    most_viewed_ids = sorted(view_counts.items(), key=lambda x: -x[1])[:8]
+    most_viewed = [p for pid, _ in most_viewed_ids for p in products if p["id"] == pid]
+    return {
+        "title":    "Anbefalt for analytikere",
+        "subtitle": "Du ser analytiker-vista — fokus på utforsking og analyse.",
+        "shortcuts": [
+            {"label": "Bla i katalog", "url": "/?tab=analytical", "icon": "bi-search"},
+            {"label": "Glossar",       "url": "/glossary",        "icon": "bi-book"},
+            {"label": "Lag analytisk produkt", "url": "/create-analytical", "icon": "bi-plus-circle"},
+        ],
+        "section_title":    "Mest brukte produkter (siste 30 dager)",
+        "section_products": most_viewed[:8],
+    }
+
+
+@app.get("/getting-started", response_class=HTMLResponse, include_in_schema=False)
+def page_getting_started(request: Request):
+    """GUIDE-1: kom-i-gang-checklist."""
+    user = auth.get_current_user(request)
+    if not user:
+        return RedirectResponse("/login?next=/getting-started", status_code=303)
+    progress = auth.get_onboarding_progress(user["id"])
+    completed_count = sum(1 for v in progress.values() if v)
+    return templates.TemplateResponse("getting_started.html", _template_ctx(
+        request,
+        steps=auth.ONBOARDING_STEPS,
+        progress=progress,
+        completed_count=completed_count,
+        total_count=len(auth.ONBOARDING_STEPS),
+        personas=auth.PERSONAS,
+    ))
+
+
+@app.post("/api/profile/persona", tags=["users"], summary="Sett egen rolle (analyst/engineer/domain_owner)")
+async def api_set_persona(request: Request):
+    user = auth.get_current_user(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Krever innlogging")
+    body = await request.json()
+    persona = body.get("persona")
+    if not auth.set_persona(user["id"], persona):
+        raise HTTPException(status_code=400, detail=f"Ugyldig persona — må være en av {auth.PERSONAS}")
+    return {"persona": persona}
+
+
+@app.post("/api/profile/onboarding/complete", tags=["users"], summary="Marker onboarding som ferdig")
+async def api_complete_onboarding(request: Request):
+    user = auth.get_current_user(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Krever innlogging")
+    auth.mark_onboarding_completed(user["id"])
+    return {"completed": True}
 
 
 @app.get("/products/{product_id}", response_class=HTMLResponse, include_in_schema=False)

--- a/dataportal/templates/base.html
+++ b/dataportal/templates/base.html
@@ -481,6 +481,12 @@
       MinIO Console
       <i class="bi bi-box-arrow-up-right ext-icon"></i>
     </a>
+    {% if current_user %}
+    <a href="/getting-started" class="sidebar-link {% if path == '/getting-started' %}active{% endif %}">
+      <i class="bi bi-rocket-takeoff link-icon" style="color:#10b981;"></i>
+      Kom i gang
+    </a>
+    {% endif %}
     <a href="/docs" target="_blank" class="sidebar-link">
       <i class="bi bi-code-slash link-icon" style="color:#8b5cf6;"></i>
       API-dokumentasjon
@@ -621,5 +627,51 @@
   })();
 </script>
 {% block scripts %}{% endblock %}
+
+{# GUIDE-1: velkomst-modal som vises én gang for brukere uten onboarding-status #}
+{% if current_user and not current_user.onboarding_completed_at and path != '/getting-started' %}
+<div class="modal fade" id="welcomeModal" tabindex="-1" aria-labelledby="welcomeModalLabel" aria-hidden="true" data-bs-backdrop="static">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header bg-primary text-white">
+        <h5 class="modal-title" id="welcomeModalLabel">
+          <i class="bi bi-rocket-takeoff me-2"></i>Velkommen til Slettix Analytics
+        </h5>
+      </div>
+      <div class="modal-body">
+        <p>
+          Slettix Analytics er en data mesh-plattform der domener publiserer dataprodukter med
+          tydelig eierskap, kontrakter og kvalitetskrav. Du kan utforske katalogen, åpne
+          notebooks i Jupyter og bygge dashboards i Superset — alt fra dataportalen.
+        </p>
+        <p class="mb-0 small text-muted">
+          Vi har laget en kort kom-i-gang-checklist som tar deg gjennom de første stegene.
+          Ukjente begreper? Sjekk Glossar i menyen.
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link text-muted" id="welcome-skip">Hopp over</button>
+        <a href="/getting-started" class="btn btn-primary">
+          <i class="bi bi-arrow-right me-1"></i>Start kom-i-gang-flyten
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    const modalEl = document.getElementById('welcomeModal');
+    if (!modalEl) return;
+    const modal = new bootstrap.Modal(modalEl);
+    modal.show();
+    document.getElementById('welcome-skip').addEventListener('click', async () => {
+      try {
+        await fetch('/api/profile/onboarding/complete', {method: 'POST'});
+      } catch (_) {}
+      modal.hide();
+    });
+  })();
+</script>
+{% endif %}
 </body>
 </html>

--- a/dataportal/templates/catalog.html
+++ b/dataportal/templates/catalog.html
@@ -3,6 +3,61 @@
 
 {% block content %}
 
+{# ── GUIDE-4: rolle-tilpassede widgets ── #}
+{% if current_user and persona_widgets %}
+<section class="card shadow-sm mb-4 border-primary border-opacity-25" style="border-left: 3px solid #0d6efd !important;">
+  <div class="card-body">
+    <div class="d-flex align-items-start gap-3 flex-wrap">
+      <div class="flex-grow-1">
+        <h2 class="h5 mb-1">{{ persona_widgets.title }}</h2>
+        <p class="text-muted small mb-2">{{ persona_widgets.subtitle }}</p>
+        <div class="d-flex gap-2 flex-wrap">
+          {% for s in persona_widgets.shortcuts %}
+            <a href="{{ s.url }}" class="btn btn-sm btn-outline-primary">
+              <i class="bi {{ s.icon }} me-1"></i>{{ s.label }}
+            </a>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="dropdown">
+        <button class="btn btn-sm btn-light border dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="bi bi-person-badge me-1"></i>
+          {% if persona == "analyst" %}Analytiker
+          {% elif persona == "engineer" %}Dataingeniør
+          {% elif persona == "domain_owner" %}Domeneeier
+          {% else %}{{ persona }}{% endif %}
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item {% if persona == 'analyst' %}active{% endif %}" href="?persona=analyst">
+            <i class="bi bi-graph-up me-1"></i>Analytiker</a></li>
+          <li><a class="dropdown-item {% if persona == 'engineer' %}active{% endif %}" href="?persona=engineer">
+            <i class="bi bi-tools me-1"></i>Dataingeniør</a></li>
+          <li><a class="dropdown-item {% if persona == 'domain_owner' %}active{% endif %}" href="?persona=domain_owner">
+            <i class="bi bi-shield-lock me-1"></i>Domeneeier</a></li>
+          <li><hr class="dropdown-divider"></li>
+          <li><a class="dropdown-item small text-muted" href="/getting-started?focus=persona">
+            <i class="bi bi-gear me-1"></i>Endre standardrolle …</a></li>
+        </ul>
+      </div>
+    </div>
+
+    {% if persona_widgets.section_products %}
+    <div class="mt-3">
+      <div class="text-muted small text-uppercase fw-semibold mb-2">{{ persona_widgets.section_title }}</div>
+      <div class="d-flex flex-wrap gap-2">
+        {% for p in persona_widgets.section_products %}
+          <a href="/products/{{ p.id }}" class="badge bg-light text-dark border text-decoration-none px-3 py-2">
+            <span class="text-muted small">{{ p.domain }}</span>
+            <span class="ms-1 fw-semibold">{{ p.name }}</span>
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</section>
+{% endif %}
+
 {# ── Header med notebook-knapp ── #}
 <div class="d-flex align-items-center mb-3">
   <div>

--- a/dataportal/templates/getting_started.html
+++ b/dataportal/templates/getting_started.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+{% block title %}Kom i gang — Slettix Data Portal{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-3" style="max-width: 920px;">
+
+  <div class="d-flex align-items-center mb-3">
+    <h1 class="h3 mb-0"><i class="bi bi-rocket-takeoff me-2 text-primary"></i>Kom i gang</h1>
+    <span class="ms-auto badge bg-light text-dark">{{ completed_count }} / {{ total_count }} steg fullført</span>
+  </div>
+  <p class="text-muted mb-4">
+    Disse stegene tar deg gjennom plattformen som ny bruker. Du kan gjøre dem i hvilken som helst rekkefølge —
+    progresjonen oppdateres automatisk når du utfører hver handling.
+  </p>
+
+  <div class="progress mb-4" style="height: 8px;">
+    <div class="progress-bar bg-success" role="progressbar"
+         style="width: {{ (completed_count / total_count * 100)|round(0) }}%;"
+         aria-valuenow="{{ completed_count }}" aria-valuemin="0" aria-valuemax="{{ total_count }}"></div>
+  </div>
+
+  {# ── Persona-seksjon ── #}
+  <div id="persona" class="card mb-4 shadow-sm">
+    <div class="card-body">
+      <h2 class="h5 mb-2"><i class="bi bi-person-badge me-2 text-primary"></i>Velg din rolle</h2>
+      <p class="text-muted small mb-3">
+        Forsiden tilpasses ut fra rolle. Du kan bytte når som helst senere fra topplinjen.
+      </p>
+      <div class="btn-group" role="group" aria-label="Velg rolle">
+        {% for p in personas %}
+        <input type="radio" class="btn-check persona-radio" name="persona" id="persona-{{ p }}" value="{{ p }}"
+               {% if (current_user.persona if current_user else None) == p %}checked{% endif %}>
+        <label class="btn btn-outline-primary" for="persona-{{ p }}">
+          {% if p == "analyst" %}<i class="bi bi-graph-up me-1"></i>Analytiker
+          {% elif p == "engineer" %}<i class="bi bi-tools me-1"></i>Dataingeniør
+          {% elif p == "domain_owner" %}<i class="bi bi-shield-lock me-1"></i>Domeneeier
+          {% else %}{{ p }}{% endif %}
+        </label>
+        {% endfor %}
+      </div>
+      <div id="persona-status" class="small text-success mt-2" style="display:none;">
+        <i class="bi bi-check-circle me-1"></i>Lagret
+      </div>
+    </div>
+  </div>
+
+  {# ── Checklist ── #}
+  <div class="list-group shadow-sm mb-4">
+    {% for step in steps %}
+    {% set done = progress[step.key] %}
+    <a href="{{ step.url }}" class="list-group-item list-group-item-action d-flex align-items-start gap-3 py-3">
+      <div class="flex-shrink-0" style="width: 32px;">
+        {% if done %}
+          <i class="bi bi-check-circle-fill text-success" style="font-size: 1.4rem;"></i>
+        {% else %}
+          <span class="badge rounded-circle bg-light text-muted border" style="width: 28px; height: 28px; line-height: 22px; font-size: .8rem;">
+            {{ loop.index }}
+          </span>
+        {% endif %}
+      </div>
+      <div class="flex-grow-1">
+        <div class="fw-semibold {% if done %}text-decoration-line-through text-muted{% endif %}">
+          {{ step.title }}
+        </div>
+        <div class="small text-muted">{{ step.description }}</div>
+      </div>
+      <div class="flex-shrink-0 align-self-center">
+        <i class="bi bi-arrow-right text-muted"></i>
+      </div>
+    </a>
+    {% endfor %}
+  </div>
+
+  {% if completed_count == total_count %}
+  <div class="alert alert-success">
+    <i class="bi bi-trophy me-1"></i>
+    <strong>Du har fullført alle stegene!</strong>
+    Glossaret og brukerguiden er fortsatt tilgjengelig fra menyen når du trenger det.
+  </div>
+  {% endif %}
+</div>
+
+<script>
+  (function () {
+    const radios = document.querySelectorAll('.persona-radio');
+    const status = document.getElementById('persona-status');
+    radios.forEach(r => r.addEventListener('change', async () => {
+      try {
+        const resp = await fetch('/api/profile/persona', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({persona: r.value}),
+        });
+        if (resp.ok) {
+          status.style.display = '';
+          setTimeout(() => location.reload(), 800);
+        }
+      } catch (_) { /* ignore */ }
+    }));
+  })();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
Bygger videre på GUIDE-2/7-fundamentet (PR #137) ved å gjøre dataportalen rolle-tilpasset og legge til en onboarding-flyt for nye brukere.

## GUIDE-1: Onboarding-flyt og kom-i-gang-checklist
- **Velkomst-modal** vises én gang i `base.html` for brukere uten `onboarding_completed_at`. «Hopp over» kaller `/api/profile/onboarding/complete`.
- **Ny side `/getting-started`** med 5-trinns checklist + persona-velger:
    1. `set_persona` — `users.persona` er satt
    2. `view_product` — minst én `usage_events.action='view'`
    3. `open_glossary` — minst én `usage_events.action='view_glossary'`
    4. `subscribe` — minst én `subscriptions`-rad
    5. `generate_notebook` — minst én `usage_events.action='generate_notebook'`
- **Stegene avledes fra eksisterende state** — ingen ekstra tabell. Progress oppdateres automatisk når brukeren utfører handlinger.
- **`api_generate_notebook` tracker nå** `generate_notebook`-event så steg 5 markeres uten ekstra UI-kall.
- **Sidebar-lenke «Kom i gang»** vises for innloggede brukere.

## GUIDE-4: Roll-baserte landingssider
- `PERSONAS = (analyst, engineer, domain_owner)`
- `get_current_user` beriker context med `persona` + `onboarding_completed_at`
- Forsiden `/` leser persona fra `?persona=` eller `user.persona` (fallback `analyst`) og bygger `_persona_landing()`-widget:
    - **analyst** — anbefalt katalog + Glossar + Lag analytisk produkt + topp 8 mest brukte produkter
    - **engineer** — Pipeline-bygger + DAG-status + Publisér + 8 produkter med `dag_id`
    - **domain_owner** — Governance + Observability + Publisér + 8 produkter brukeren eier eller har domeneprivilegier på
- **Persona-toggle (dropdown)** på forsiden lar brukeren bytte vista uten å endre standardrolle
- **`/api/profile/persona`** setter standardrolle persistent

## DB-migrasjon
`auth.init_db()` legger til `persona` og `onboarding_completed_at` på `users` via `PRAGMA table_info` (idempotent — kjøres trygt på eksisterende DB). Verifisert lokalt:
```
users-kolonner: [id, username, email, password_hash, role, created_at, persona, onboarding_completed_at]
```

## Endringer
- `dataportal/auth.py` — `PERSONAS`, idempotent migrasjon, `set_persona`/`get_persona`/`get_onboarding_progress`/`mark_onboarding_completed`/`is_onboarding_completed`, `ONBOARDING_STEPS`
- `dataportal/main.py` — `/getting-started`, `/api/profile/persona`, `/api/profile/onboarding/complete`, `_persona_landing()`, generate_notebook-tracking
- `dataportal/templates/getting_started.html` (ny)
- `dataportal/templates/base.html` — velkomst-modal, sidebar-lenke
- `dataportal/templates/catalog.html` — rolle-widget med toggle

## Verifisert
- `GET /getting-started` (uten auth) → 303 redirect til `/login?next=/getting-started`
- `GET /?persona=engineer` → 200 OK på ~225 ms
- DB-migrasjon kjører rent på eksisterende `auth.db` (begge nye kolonner finnes)

## Kommentar om koblinger
- Steg 3 (`open_glossary`) tracker via `view_glossary`-event som vil bli emitert av `/glossary`-endepunktet i PR #137. Inntil PR #137 er merget vil det steget aldri markeres som fullført — tracking-kallet kan legges til som follow-up etter merge.
- Persona-toggle bruker glossar-lenke som først blir tilgjengelig etter PR #137.

## Closes
Closes #124, #127

## Test plan
- [ ] Logg inn som ny bruker → velkomst-modal vises
- [ ] Klikk «Start kom-i-gang-flyten» → /getting-started åpnes
- [ ] Velg en persona → siden reloader og forsidens widget viser tilpasset innhold
- [ ] Bytt vista i topplinje-dropdown → forsiden tilpasser seg
- [ ] Generer en notebook → steg 5 i checklist markeres som fullført

🤖 Generated with [Claude Code](https://claude.com/claude-code)