### PR TITLE
feat(portal): visuell plattform-oversikt og FAQ-side (GUIDE-3 + GUIDE-10)

### DIFF
--- a/dataportal/help/01-find-owner.md
+++ b/dataportal/help/01-find-owner.md
@@ -1,0 +1,12 @@
+---
+title: Hvor finner jeg eieren av et dataprodukt?
+category: faq
+slug: find-owner
+---
+
+Eieren vises på produktdetaljsiden under produktnavnet, i formatet
+`<domene> / <eier>`. Eier er enten et person- eller team-brukernavn fra
+auth-systemet.
+
+Trenger du å kontakte eieren? Bruk bedriftens vanlige kanaler — eierfeltet
+forteller hvem som er ansvarlig, men ikke hvor du finner dem.

--- a/dataportal/help/02-request-access.md
+++ b/dataportal/help/02-request-access.md
@@ -1,0 +1,14 @@
+---
+title: Hvordan ber jeg om tilgang til et restricted produkt?
+category: faq
+slug: request-access
+---
+
+Restricted produkter krever eksplisitt godkjenning. Slik gjør du:
+
+1. Åpne produktdetaljsiden — den viser et **«Begrenset tilgang»**-banner.
+2. Klikk **«Be om tilgang»**.
+3. Forespørselen sendes til admin/eier som godkjenner eller avslår.
+
+Du får tilgang neste gang du logger inn, eller umiddelbart om du oppdaterer
+siden etter godkjenning.

--- a/dataportal/help/03-bronze-vs-silver.md
+++ b/dataportal/help/03-bronze-vs-silver.md
@@ -1,0 +1,18 @@
+---
+title: Hva er forskjellen på Bronze, Silver og Gold?
+category: faq
+slug: bronze-silver-gold
+---
+
+Plattformen bruker **Medallion-arkitekturen** — tre lag der data foredles:
+
+- **Bronze** — råinntak fra Kafka, lagret som hendelser uten transformasjon.
+  Brukes til reprosessering.
+- **Silver** — rensede og konformerte tabeller. Hovedstedet for
+  domeneprodukter som `person_registry`.
+- **Gold** — aggregerte, analytiske produkter optimalisert for BI og notebooks.
+
+Som analytiker skal du nesten alltid lese fra **Silver** eller **Gold** —
+Bronze er typisk reservert for plattformteam ved feilsøking.
+
+Se [Glossar](/glossary#medallion) for mer.

--- a/dataportal/help/04-publish-product.md
+++ b/dataportal/help/04-publish-product.md
@@ -1,0 +1,18 @@
+---
+title: Hvordan publiserer jeg et nytt dataprodukt?
+category: faq
+slug: publish-product
+---
+
+Tre veier, avhengig av produkttypen:
+
+1. **Analytisk produkt** (avledet fra eksisterende data): bruk veiviseren
+   under **Lag → Analytisk produkt** i sidemenyen, eller
+   `publish_analytical()` fra Jupyter.
+2. **Pipeline-basert produkt** (ny Bronze/Silver/Gold-jobb): bruk
+   **Bygg → Pipeline-bygger** for å generere DAG og Spark-jobb fra mal.
+3. **Manuell registrering**: kall `register(manifest)` direkte fra Jupyter
+   eller via `POST /api/products` med X-API-Key.
+
+Alle veier ender med at manifestet registreres i Delta-registret og blir
+synlig i katalogen.

--- a/dataportal/help/05-subscribe.md
+++ b/dataportal/help/05-subscribe.md
@@ -1,0 +1,14 @@
+---
+title: Hvordan får jeg varsel når et produkt endres?
+category: faq
+slug: subscribe-changes
+---
+
+Klikk **Abonner**-knappen på produktdetaljsiden. Du får varsel når:
+
+- Schema endres (kolonne lagt til/fjernet, type-endring)
+- SLO-endringer (freshness, completeness)
+- Nye versjoner publiseres
+
+Varsler sendes via konfigurert kanal (Slack-webhook hvis satt). Avslutt
+abonnement med samme knapp.

--- a/dataportal/help/06-pii-access.md
+++ b/dataportal/help/06-pii-access.md
@@ -1,0 +1,16 @@
+---
+title: Hvorfor ser jeg "***" istedenfor data?
+category: faq
+slug: pii-masked
+---
+
+Kolonner merket med **PII** maskeres automatisk for brukere som ikke har
+PII-tilgang. Du ser `***` i schema-tabellen og i query-resultater.
+
+For å få tilgang til PII-data:
+
+1. Sjekk om du har riktig domeneprivilegium (vises i din profil).
+2. Hvis ikke — be admin om PII-tilgang i ditt domene.
+3. Gå deretter tilbake til produktet — maskeringen oppheves automatisk.
+
+Se [Glossar — PII](/glossary#pii).

--- a/dataportal/help/07-sla-breach.md
+++ b/dataportal/help/07-sla-breach.md
@@ -1,0 +1,17 @@
+---
+title: Hva betyr "SLA-brudd" på et produkt?
+category: faq
+slug: sla-breach
+---
+
+SLA-bruddet vises som rødt merke på katalog- og produktdetaljside.
+Det betyr at tabellen ikke er oppdatert innenfor avtalt
+`freshness_hours` — pipeline-en har enten feilet, henger eller er
+forsinket.
+
+Se etter:
+
+- Status-merke under **SLA-ferskhet** på produktdetaljsiden — viser
+  timer siden siste oppdatering.
+- Pipeline-status under **Datalineage** eller på **Pipelines**-siden.
+- Eier av produktet er ansvarlig — kontakt dem hvis det haster.

--- a/dataportal/help/08-jupyter-credentials.md
+++ b/dataportal/help/08-jupyter-credentials.md
@@ -1,0 +1,20 @@
+---
+title: Hvor finner jeg credentials for å lese fra Jupyter?
+category: faq
+slug: jupyter-credentials
+---
+
+Notebookene du genererer fra portalen har boilerplate som leser
+credentials fra miljøvariablene `AWS_ACCESS_KEY_ID` og
+`AWS_SECRET_ACCESS_KEY`. Disse er allerede satt i Jupyter-poden via
+ConfigMap, så vanligvis trenger du **ikke å gjøre noe**.
+
+Hvis du kjører lokalt:
+
+```bash
+export AWS_ACCESS_KEY_ID=admin
+export AWS_SECRET_ACCESS_KEY=changeme
+export AWS_ENDPOINT_URL=http://localhost:9000
+```
+
+For produksjon: bruk din personlige tilgang via SSO-integrasjonen.

--- a/dataportal/help/09-superset-data.md
+++ b/dataportal/help/09-superset-data.md
@@ -1,0 +1,17 @@
+---
+title: Hvordan bruker jeg et dataprodukt i Superset?
+category: faq
+slug: superset-usage
+---
+
+Klikk **«Utforsk i Superset»** på produktdetaljsiden — det åpner SQL Lab
+med en pre-konfigurert spørring mot dataproduktets Delta-tabell.
+
+Derfra kan du:
+
+- Bygge charts i SQL Lab og lagre til et dashboard
+- Lagre spørringen som et "saved query" for gjenbruk
+- Eksportere CSV/Excel
+
+Datakilden er allerede registrert globalt i Superset, så du trenger
+ikke å sette opp connection.

--- a/dataportal/help/10-schema-compatibility.md
+++ b/dataportal/help/10-schema-compatibility.md
@@ -1,0 +1,23 @@
+---
+title: Hva er schema-kompatibilitet og hvorfor blokkerer det publisering?
+category: faq
+slug: schema-compatibility
+---
+
+Schema-kompatibilitet er regelen som forhindrer at du publiserer en
+breaking endring uten varsel. Når du publiserer et oppdatert manifest,
+sjekkes det nye skjemaet mot kontraktens kompatibilitetsmodus:
+
+- **BACKWARD** — kun trygge endringer (legge til nullable kolonner)
+- **FORWARD** — kun trygge endringer (fjerne nullable kolonner)
+- **FULL** — kun additive endringer
+- **NONE** — alt er tillatt (men risikabelt)
+
+Hvis sjekken feiler får du `409 Conflict` med detaljer om hvilke
+endringer som bryter kontrakten. Løsninger:
+
+1. Øk **major-versjon** og oppdater kompatibilitetsmodus
+2. Endre kontrakten til `NONE` (kun ved godkjenning fra eier)
+3. Justér skjemaet ditt slik at det er bakoverkompatibelt
+
+Se [Glossar — Schema-kompatibilitet](/glossary#schema-compatibility).

--- a/dataportal/help/t01-dag-oom.md
+++ b/dataportal/help/t01-dag-oom.md
@@ -1,0 +1,24 @@
+---
+title: "DAG-en min feiler med OOMKilled"
+category: troubleshoot
+slug: dag-oom
+---
+
+OOMKill betyr at en task brukte mer minne enn pod-limit'et. Vanlige årsaker:
+
+- **Pandas på store tabeller** — pandas DataFrame er typisk 5-10x parquet-størrelsen.
+  Kjør jobben som Spark istedet (se `jobs/folkeregister_validate_quality.py`
+  for eksempel på hvordan validering er flyttet til Spark).
+- **`.collect()` i Spark** — drar hele tabellen inn i driver-pod-en.
+  Bruk `.write` eller `.toPandas(arrow_enabled=True)` med `.limit()`.
+- **For mange parallelle Spark-jobber** — kjør sekvensielt eller gi
+  Spark Operator mer minne.
+
+Sjekk pod-status:
+
+```bash
+kubectl describe pod -n slettix-analytics <pod-name>
+```
+
+Hvis det står `OOMKilled` under `Last State`, øk `memory`-limit i
+Helm-values eller spark-app-template.

--- a/dataportal/help/t02-portal-401.md
+++ b/dataportal/help/t02-portal-401.md
@@ -1,0 +1,25 @@
+---
+title: "Jeg får 401 Unauthorized fra portal-API"
+category: troubleshoot
+slug: portal-401
+---
+
+Portal-API krever enten:
+
+- **Innlogget bruker** (cookie satt via `/login`)
+- **Gyldig X-API-Key** (header `X-API-Key: <key>`)
+
+Sjekk:
+
+```bash
+# Verifiser at API-key er korrekt
+echo $PORTAL_API_KEY
+
+# Test med curl
+curl -H "X-API-Key: $PORTAL_API_KEY" http://localhost:8090/api/products
+```
+
+Hvis nøkkelen er korrekt men du fortsatt får 401: pod-en kan ha
+restartet og lest en ny `slettix-credentials`-secret. Sjekk
+`kubectl describe pod` og restart Airflow scheduler hvis
+`PORTAL_API_KEY` er satt fra secret.

--- a/dataportal/help/t03-jupyter-minio.md
+++ b/dataportal/help/t03-jupyter-minio.md
@@ -1,0 +1,27 @@
+---
+title: "Notebook kan ikke koble til MinIO"
+category: troubleshoot
+slug: jupyter-minio
+---
+
+Tre vanlige årsaker:
+
+1. **Feil endpoint-URL**: bruk `http://minio.slettix-analytics.svc.cluster.local:9000`
+   internt i Kubernetes, eller `http://localhost:9000` lokalt.
+2. **Manglende credentials**: sjekk `AWS_ACCESS_KEY_ID` og `AWS_SECRET_ACCESS_KEY`
+   i Jupyter-pod-ens env-vars. De settes via `slettix-credentials`-secret.
+3. **MinIO under cold start**: ved første kall etter cluster-oppstart kan
+   MinIO trenge ~10-30 sek på å være klar. Forsøk igjen.
+
+Test fra Jupyter:
+
+```python
+import boto3
+s3 = boto3.client(
+    "s3",
+    endpoint_url="http://minio.slettix-analytics.svc.cluster.local:9000",
+)
+print(s3.list_buckets())
+```
+
+Forventet output: liste over buckets (`raw`, `bronze`, `silver`, `gold` ...).

--- a/dataportal/help/t04-spark-403.md
+++ b/dataportal/help/t04-spark-403.md
@@ -1,0 +1,32 @@
+---
+title: "Spark-jobben min får 403 Forbidden mot MinIO"
+category: troubleshoot
+slug: spark-403
+---
+
+403 Forbidden fra S3A-driver betyr enten manglende eller feil credentials.
+
+Sjekk SparkApplication-spec:
+
+```yaml
+driver:
+  env:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef: {name: slettix-credentials, key: minio-root-user}
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef: {name: slettix-credentials, key: minio-root-password}
+executor:
+  env:
+    # SAMME som driver — executors har egne env-vars
+```
+
+**Vanlig glipp**: env satt kun på driver, ikke på executor.
+
+Konfigurer også S3A-credentials provider i `sparkConf`:
+
+```yaml
+"spark.hadoop.fs.s3a.aws.credentials.provider":
+  "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+```

--- a/dataportal/help/t05-empty-table.md
+++ b/dataportal/help/t05-empty-table.md
@@ -1,0 +1,28 @@
+---
+title: "Pipeline-en kjørte 'success' men tabellen er tom"
+category: troubleshoot
+slug: empty-table
+---
+
+Pipeline kan rapportere success uten å ha skrevet noe — typisk når
+filteret ikke matcher noe i kilden. Sjekk:
+
+1. **Sammenlign runtime**: en typisk Silver-jobb tar minutter. Hvis den
+   tok < 1 min, mistenker tomt resultat.
+2. **Sjekk filter i Spark-jobben**: er event-typer/dato-filter korrekt?
+3. **Inspiser Bronze-data**:
+
+   ```python
+   from pyspark.sql import SparkSession, functions as F
+   spark = SparkSession.builder.getOrCreate()
+   df = spark.read.format("delta").load("s3a://bronze/<domene>/<tabell>")
+   df.groupBy("event_type").count().show()
+   ```
+
+4. **Sjekk validate_quality**: hvis et produkt har tom tabell, vil
+   `expect_table_row_count_to_be_between(min_value=1)` fange det opp og
+   markere kvalitet som < 100%.
+
+Eksempel: residence_history-bug i april 2026 — filteret matchet kun
+`event.relocation`, men kilden inneholdt kun `citizen.created`. Fikset
+ved å utvide filteret. Se commit-historikk for `folkeregister_residence_history.py`.

--- a/dataportal/help_content.py
+++ b/dataportal/help_content.py
@@ -1,0 +1,91 @@
+"""
+GUIDE-10: FAQ og feilløsninger lest fra markdown-filer i help/.
+
+Hver fil har YAML-lignende frontmatter med metadata:
+
+    ---
+    title: "Hvor finner jeg eieren av et produkt?"
+    category: faq
+    slug: find-owner
+    ---
+    Markdown-body her …
+
+Ved kall hentes filer fra `help/`-katalogen, parses og caches i prosessminne
+til oppstart neste gang. Kategorier:
+
+  faq           — ofte stilte spørsmål
+  troubleshoot  — kjente feil og hvordan løse dem
+"""
+
+import pathlib
+import re
+
+import markdown as _md
+
+
+HELP_DIR = pathlib.Path(__file__).parent / "help"
+
+CATEGORIES = [
+    ("faq",          "Ofte stilte spørsmål"),
+    ("troubleshoot", "Vanlige feil og løsninger"),
+]
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n(.*)$", re.DOTALL)
+_KV_RE = re.compile(r"^([a-zA-Z_]+):\s*(.*)$")
+
+
+def _parse_one(path: pathlib.Path) -> dict | None:
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    meta_block, body = m.group(1), m.group(2)
+    meta: dict = {}
+    for line in meta_block.splitlines():
+        kv = _KV_RE.match(line.strip())
+        if kv:
+            value = kv.group(2).strip().strip('"').strip("'")
+            meta[kv.group(1)] = value
+    if not all(k in meta for k in ("title", "category", "slug")):
+        return None
+    body_html = _md.markdown(body, extensions=["fenced_code", "tables"])
+    return {
+        "slug":     meta["slug"],
+        "title":    meta["title"],
+        "category": meta["category"],
+        "tags":     [t.strip() for t in meta.get("tags", "").split(",") if t.strip()],
+        "body":     body_html,
+        "search":   (meta["title"] + " " + body).lower(),
+    }
+
+
+_CACHE: list[dict] | None = None
+
+
+def all_entries() -> list[dict]:
+    """Les og cache alle help-entries. Sorterer alfabetisk innen kategori."""
+    global _CACHE
+    if _CACHE is not None:
+        return _CACHE
+    if not HELP_DIR.exists():
+        _CACHE = []
+        return _CACHE
+    entries = []
+    for path in sorted(HELP_DIR.glob("*.md")):
+        entry = _parse_one(path)
+        if entry:
+            entries.append(entry)
+    _CACHE = entries
+    return _CACHE
+
+
+def by_category() -> list[tuple[str, str, list[dict]]]:
+    grouped: dict[str, list[dict]] = {c: [] for c, _ in CATEGORIES}
+    for e in all_entries():
+        cat = e.get("category", "")
+        if cat in grouped:
+            grouped[cat].append(e)
+    for cat in grouped:
+        grouped[cat].sort(key=lambda e: e["title"].lower())
+    return [(slug, label, grouped[slug]) for slug, label in CATEGORIES if grouped[slug]]

--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -95,6 +95,7 @@ from registry import (  # noqa: E402
 
 import auth  # noqa: E402
 import glossary  # noqa: E402
+import help_content  # noqa: E402
 
 # ── oppstart ───────────────────────────────────────────────────────────────────
 
@@ -3436,11 +3437,30 @@ def page_browse_redirect(request: Request):
 @app.get("/glossary", response_class=HTMLResponse, include_in_schema=False)
 def page_glossary(request: Request):
     """GUIDE-2: plattform-glossar med søk og kategorier."""
+    user = auth.get_current_user(request)
+    if user:
+        # Markerer onboarding-steget «open_glossary» for innloggede brukere.
+        auth.track_usage("__platform__", "view_glossary", user["id"])
     return templates.TemplateResponse("glossary.html", _template_ctx(
         request,
         terms=glossary.all_terms(),
         terms_by_slug=glossary.GLOSSARY,
         by_category=glossary.by_category(),
+    ))
+
+
+@app.get("/how-it-works", response_class=HTMLResponse, include_in_schema=False)
+def page_how_it_works(request: Request):
+    """GUIDE-3: visuell plattform-oversikt med interaktivt arkitektur-diagram."""
+    return templates.TemplateResponse("how_it_works.html", _template_ctx(request))
+
+
+@app.get("/help", response_class=HTMLResponse, include_in_schema=False)
+def page_help(request: Request):
+    """GUIDE-10: FAQ og kjente feilløsninger."""
+    return templates.TemplateResponse("help.html", _template_ctx(
+        request,
+        by_category=help_content.by_category(),
     ))
 
 

--- a/dataportal/templates/base.html
+++ b/dataportal/templates/base.html
@@ -487,9 +487,17 @@
       Kom i gang
     </a>
     {% endif %}
+    <a href="/how-it-works" class="sidebar-link {% if path == '/how-it-works' %}active{% endif %}">
+      <i class="bi bi-diagram-2 link-icon" style="color:#a855f7;"></i>
+      Hvordan det fungerer
+    </a>
     <a href="/glossary" class="sidebar-link {% if path == '/glossary' %}active{% endif %}">
       <i class="bi bi-book link-icon" style="color:#0ea5e9;"></i>
       Glossar
+    </a>
+    <a href="/help" class="sidebar-link {% if path == '/help' %}active{% endif %}">
+      <i class="bi bi-life-preserver link-icon" style="color:#f59e0b;"></i>
+      Hjelp og FAQ
     </a>
     <a href="/docs" target="_blank" class="sidebar-link">
       <i class="bi bi-code-slash link-icon" style="color:#8b5cf6;"></i>

--- a/dataportal/templates/help.html
+++ b/dataportal/templates/help.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block title %}Hjelp og FAQ — Slettix Data Portal{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-3" style="max-width: 1100px;">
+
+  <h1 class="h3 mb-3"><i class="bi bi-life-preserver me-2 text-primary"></i>Hjelp og FAQ</h1>
+  <p class="text-muted mb-4">
+    Ofte stilte spørsmål og kjente feil. Søk etter ord eller bla i kategoriene.
+    Mangler noe? Si fra til plattformteamet, så legger vi til.
+  </p>
+
+  <div class="row mb-4">
+    <div class="col-md-6">
+      <div class="input-group">
+        <span class="input-group-text"><i class="bi bi-search"></i></span>
+        <input id="help-search" type="text" class="form-control" autofocus
+               placeholder="Søk i FAQ og feilløsninger …">
+      </div>
+    </div>
+  </div>
+
+  {% for cat_slug, cat_label, cat_entries in by_category %}
+  <section class="help-category mb-5" data-category="{{ cat_slug }}">
+    <h2 class="h5 mb-3 text-uppercase text-muted small">
+      {% if cat_slug == "troubleshoot" %}<i class="bi bi-exclamation-triangle me-1"></i>{% else %}<i class="bi bi-question-circle me-1"></i>{% endif %}
+      {{ cat_label }}
+    </h2>
+    <div class="accordion" id="acc-{{ cat_slug }}">
+      {% for entry in cat_entries %}
+      <div class="accordion-item help-entry-wrap" data-search="{{ entry.search }}">
+        <h3 class="accordion-header" id="heading-{{ entry.slug }}">
+          <button class="accordion-button collapsed" type="button"
+                  data-bs-toggle="collapse" data-bs-target="#collapse-{{ entry.slug }}"
+                  aria-expanded="false" aria-controls="collapse-{{ entry.slug }}">
+            <span id="{{ entry.slug }}">{{ entry.title }}</span>
+          </button>
+        </h3>
+        <div id="collapse-{{ entry.slug }}" class="accordion-collapse collapse"
+             aria-labelledby="heading-{{ entry.slug }}" data-bs-parent="#acc-{{ cat_slug }}">
+          <div class="accordion-body small">
+            {{ entry.body|safe }}
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+  {% endfor %}
+
+  <div id="help-empty" class="text-center text-muted py-5" style="display:none;">
+    <i class="bi bi-search" style="font-size:2rem;"></i>
+    <p class="mt-2">Ingen treff. Prøv et annet søkeord.</p>
+  </div>
+</div>
+
+<script>
+  (function () {
+    const input = document.getElementById('help-search');
+    const wraps = document.querySelectorAll('.help-entry-wrap');
+    const sections = document.querySelectorAll('.help-category');
+    const empty = document.getElementById('help-empty');
+
+    function applyFilter() {
+      const q = (input.value || '').trim().toLowerCase();
+      let visible = 0;
+      wraps.forEach(w => {
+        const hit = !q || (w.dataset.search || '').includes(q);
+        w.style.display = hit ? '' : 'none';
+        if (hit) visible++;
+      });
+      sections.forEach(s => {
+        const hasVisible = !!s.querySelector('.help-entry-wrap[style=""], .help-entry-wrap:not([style*="none"])');
+        s.style.display = hasVisible ? '' : 'none';
+      });
+      empty.style.display = visible === 0 ? '' : 'none';
+    }
+
+    input.addEventListener('input', applyFilter);
+
+    // Hopp direkte til entry hvis URL har anker
+    if (window.location.hash) {
+      const target = document.querySelector(window.location.hash);
+      if (target) {
+        const collapse = target.closest('.accordion-item')?.querySelector('.accordion-collapse');
+        if (collapse) new bootstrap.Collapse(collapse, {show: true});
+      }
+    }
+  })();
+</script>
+{% endblock %}

--- a/dataportal/templates/how_it_works.html
+++ b/dataportal/templates/how_it_works.html
@@ -14,15 +14,15 @@
     <div class="card-body p-2">
       <div class="mermaid" style="text-align:center;">
 flowchart LR
-  KAFKA["📨 Kafka<br/>events"]:::source
-  IDP{{"⚡ IDP-er<br/>(streaming Spark)"}}:::compute
-  BRONZE[("🟫 Bronze<br/>raw events")]:::bronze
-  SILVER[("🪙 Silver<br/>konformerte")]:::silver
-  GOLD[("🏅 Gold<br/>analytiske")]:::gold
-  AIRFLOW{{"🗓️ Airflow<br/>(batch DAG-er)"}}:::compute
-  PORTAL["🧭 Dataportal<br/>katalog/styring"]:::ui
-  JUPYTER["📓 Jupyter<br/>analyse"]:::ui
-  SUPERSET["📊 Superset<br/>dashboard"]:::ui
+  KAFKA["Kafka<br/>events"]:::source
+  IDP{{"IDP-er<br/>streaming Spark"}}:::compute
+  BRONZE[("Bronze<br/>raw events")]:::bronze
+  SILVER[("Silver<br/>konformerte")]:::silver
+  GOLD[("Gold<br/>analytiske")]:::gold
+  AIRFLOW{{"Airflow<br/>batch DAG-er"}}:::compute
+  PORTAL["Dataportal<br/>katalog og styring"]:::ui
+  JUPYTER["Jupyter<br/>analyse"]:::ui
+  SUPERSET["Superset<br/>dashboard"]:::ui
 
   KAFKA --> IDP
   IDP --> BRONZE
@@ -43,15 +43,15 @@ flowchart LR
   classDef gold    fill:#fef08a,stroke:#a16207,color:#713f12;
   classDef ui      fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a;
 
-  click KAFKA       openInfo "kafka"
-  click IDP         openInfo "idp"
-  click BRONZE      openInfo "bronze"
-  click SILVER      openInfo "silver"
-  click GOLD        openInfo "gold"
-  click AIRFLOW     openInfo "airflow"
-  click PORTAL      openInfo "portal"
-  click JUPYTER     openInfo "jupyter"
-  click SUPERSET    openInfo "superset"
+  click KAFKA    call openInfo("kafka")
+  click IDP      call openInfo("idp")
+  click BRONZE   call openInfo("bronze")
+  click SILVER   call openInfo("silver")
+  click GOLD     call openInfo("gold")
+  click AIRFLOW  call openInfo("airflow")
+  click PORTAL   call openInfo("portal")
+  click JUPYTER  call openInfo("jupyter")
+  click SUPERSET call openInfo("superset")
       </div>
     </div>
   </div>

--- a/dataportal/templates/how_it_works.html
+++ b/dataportal/templates/how_it_works.html
@@ -44,14 +44,14 @@ flowchart LR
   classDef gold    fill:#fef08a,stroke:#a16207,color:#713f12;
   classDef ui      fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a;
 
-  click KAFKA    call openInfo("kafka")
-  click IDP      call openInfo("idp")
-  click BRONZE   call openInfo("bronze")
-  click SILVER   call openInfo("silver")
-  click GOLD     call openInfo("gold")
-  click AIRFLOW  call openInfo("airflow")
-  click PORTAL   call openInfo("portal")
-  click JUPYTER  call openInfo("jupyter")
+  click KAFKA call openInfo("kafka")
+  click IDP call openInfo("idp")
+  click BRONZE call openInfo("bronze")
+  click SILVER call openInfo("silver")
+  click GOLD call openInfo("gold")
+  click AIRFLOW call openInfo("airflow")
+  click PORTAL call openInfo("portal")
+  click JUPYTER call openInfo("jupyter")
   click SUPERSET call openInfo("superset")
 {% endraw %}
       </div>

--- a/dataportal/templates/how_it_works.html
+++ b/dataportal/templates/how_it_works.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+{% block title %}Hvordan plattformen henger sammen — Slettix Data Portal{% endblock %}
+
+{% block content %}
+<div class="container-fluid py-3" style="max-width: 1100px;">
+
+  <h1 class="h3 mb-3"><i class="bi bi-diagram-2 me-2 text-primary"></i>Hvordan plattformen henger sammen</h1>
+  <p class="text-muted mb-4">
+    Klikk på en komponent for å se hva den gjør og hvor du finner relevante
+    konsepter i glossaret.
+  </p>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-body p-2">
+      <div class="mermaid" style="text-align:center;">
+flowchart LR
+  KAFKA["📨 Kafka<br/>events"]:::source
+  IDP{{"⚡ IDP-er<br/>(streaming Spark)"}}:::compute
+  BRONZE[("🟫 Bronze<br/>raw events")]:::bronze
+  SILVER[("🪙 Silver<br/>konformerte")]:::silver
+  GOLD[("🏅 Gold<br/>analytiske")]:::gold
+  AIRFLOW{{"🗓️ Airflow<br/>(batch DAG-er)"}}:::compute
+  PORTAL["🧭 Dataportal<br/>katalog/styring"]:::ui
+  JUPYTER["📓 Jupyter<br/>analyse"]:::ui
+  SUPERSET["📊 Superset<br/>dashboard"]:::ui
+
+  KAFKA --> IDP
+  IDP --> BRONZE
+  BRONZE --> AIRFLOW
+  AIRFLOW --> SILVER
+  SILVER --> AIRFLOW
+  AIRFLOW --> GOLD
+  SILVER --> JUPYTER
+  GOLD --> JUPYTER
+  GOLD --> SUPERSET
+  PORTAL -.->|publiserer manifest| SILVER
+  PORTAL -.->|trigger| AIRFLOW
+
+  classDef source  fill:#fde68a,stroke:#b45309,color:#78350f;
+  classDef compute fill:#ddd6fe,stroke:#6d28d9,color:#4c1d95;
+  classDef bronze  fill:#fed7aa,stroke:#c2410c,color:#7c2d12;
+  classDef silver  fill:#e5e7eb,stroke:#6b7280,color:#1f2937;
+  classDef gold    fill:#fef08a,stroke:#a16207,color:#713f12;
+  classDef ui      fill:#bfdbfe,stroke:#1d4ed8,color:#1e3a8a;
+
+  click KAFKA       openInfo "kafka"
+  click IDP         openInfo "idp"
+  click BRONZE      openInfo "bronze"
+  click SILVER      openInfo "silver"
+  click GOLD        openInfo "gold"
+  click AIRFLOW     openInfo "airflow"
+  click PORTAL      openInfo "portal"
+  click JUPYTER     openInfo "jupyter"
+  click SUPERSET    openInfo "superset"
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
+      <h2 class="h6 text-muted text-uppercase small mb-2">Lag i Medallion</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item d-flex justify-content-between">
+          <span><span class="badge me-2" style="background:#fed7aa;color:#7c2d12;">Bronze</span>Råinntak fra Kafka</span>
+          <a href="/glossary#bronze" class="small text-decoration-none">Glossar →</a>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span><span class="badge me-2" style="background:#e5e7eb;color:#1f2937;">Silver</span>Domeneprodukter</span>
+          <a href="/glossary#silver" class="small text-decoration-none">Glossar →</a>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span><span class="badge me-2" style="background:#fef08a;color:#713f12;">Gold</span>Analytiske aggregater</span>
+          <a href="/glossary#gold" class="small text-decoration-none">Glossar →</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-md-6">
+      <h2 class="h6 text-muted text-uppercase small mb-2">Konsepter</h2>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item d-flex justify-content-between">
+          <span>Data Mesh</span>
+          <a href="/glossary#data-mesh" class="small text-decoration-none">Glossar →</a>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span>Datakontrakt</span>
+          <a href="/glossary#data-contract" class="small text-decoration-none">Glossar →</a>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span>SLA og freshness</span>
+          <a href="/glossary#sla" class="small text-decoration-none">Glossar →</a>
+        </li>
+        <li class="list-group-item d-flex justify-content-between">
+          <span>Lineage</span>
+          <a href="/glossary#lineage" class="small text-decoration-none">Glossar →</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{# Modal som viser detaljer for klikk-bare noder #}
+<div class="modal fade" id="nodeInfoModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="nodeInfoTitle">—</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Lukk"></button>
+      </div>
+      <div class="modal-body" id="nodeInfoBody">—</div>
+      <div class="modal-footer">
+        <a id="nodeInfoLink" href="#" class="btn btn-sm btn-outline-primary">
+          <i class="bi bi-book me-1"></i>Åpne i glossar
+        </a>
+        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Lukk</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js"></script>
+<script>
+  mermaid.initialize({startOnLoad: true, theme: 'default', securityLevel: 'loose'});
+
+  const NODE_INFO = {
+    kafka:    {title: "Kafka — event-strømmer",
+               body:  "Hendelser fra kildesystemer leveres som meldinger i Kafka-topics. IDP-ene leser disse og skriver dem til Bronze.",
+               glossary: null},
+    idp:      {title: "IDP — Inbound Data Pipeline",
+               body:  "Spark Structured Streaming-jobb som kontinuerlig leser Kafka og skriver til Bronze i sanntid.",
+               glossary: "idp"},
+    bronze:   {title: "Bronze — råinntak",
+               body:  "Hendelsesdata lagret uendret fra Kafka. Bevarer alle felter slik at vi kan reprosessere ved feil eller endringer.",
+               glossary: "bronze"},
+    silver:   {title: "Silver — konformerte produkter",
+               body:  "Rensede, validerte og konformerte tabeller. Domeneprodukter med eier, kontrakt, kvalitetskrav.",
+               glossary: "silver"},
+    gold:     {title: "Gold — analytiske produkter",
+               body:  "Aggregerte tabeller optimalisert for spørringer i Superset, Jupyter og BI-verktøy.",
+               glossary: "gold"},
+    airflow:  {title: "Airflow — batch-orkestrering",
+               body:  "Kjører batch-DAG-er som transformerer Bronze → Silver → Gold på timeplan. Bruker Spark via SparkKubernetesOperator.",
+               glossary: null},
+    portal:   {title: "Dataportal — katalog og styring",
+               body:  "Sentralpunkt: katalogsøk, manifest-publisering, kvalitet- og SLA-overvåking, lineage, governance.",
+               glossary: null},
+    jupyter:  {title: "Jupyter — utforsking og analyse",
+               body:  "Interaktivt notebook-miljø. Generér notebook fra produktdetaljside med ferdig boilerplate.",
+               glossary: null},
+    superset: {title: "Superset — dashboards og SQL",
+               body:  "BI-grensesnitt for ad-hoc spørringer (SQL Lab) og dashboards mot Gold-tabellene.",
+               glossary: null},
+  };
+
+  // Mermaid-click-bindings — kalles fra grafen
+  window.openInfo = function (key) {
+    const info = NODE_INFO[key];
+    if (!info) return;
+    document.getElementById('nodeInfoTitle').textContent = info.title;
+    document.getElementById('nodeInfoBody').textContent = info.body;
+    const link = document.getElementById('nodeInfoLink');
+    if (info.glossary) {
+      link.href = "/glossary#" + info.glossary;
+      link.style.display = '';
+    } else {
+      link.style.display = 'none';
+    }
+    new bootstrap.Modal(document.getElementById('nodeInfoModal')).show();
+  };
+</script>
+{% endblock %}

--- a/dataportal/templates/how_it_works.html
+++ b/dataportal/templates/how_it_works.html
@@ -13,6 +13,7 @@
   <div class="card shadow-sm mb-4">
     <div class="card-body p-2">
       <div class="mermaid" style="text-align:center;">
+{% raw %}
 flowchart LR
   KAFKA["Kafka<br/>events"]:::source
   IDP{{"IDP-er<br/>streaming Spark"}}:::compute
@@ -52,6 +53,7 @@ flowchart LR
   click PORTAL   call openInfo("portal")
   click JUPYTER  call openInfo("jupyter")
   click SUPERSET call openInfo("superset")
+{% endraw %}
       </div>
     </div>
   </div>

--- a/docker/dataportal/requirements.txt
+++ b/docker/dataportal/requirements.txt
@@ -6,6 +6,7 @@ pyarrow==17.0.0
 pandas==2.2.2
 boto3==1.35.0
 jinja2==3.1.4
+markdown==3.7
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==3.2.2


### PR DESCRIPTION
## Summary
To nye sider som bygger på glossaret (#137) og runder av kjerne-dokumentasjonen i epic #123:

- **GUIDE-3 `/how-it-works`** — interaktivt mermaid-diagram av dataflyten, klikkbare noder med forklaring og glossar-lenke
- **GUIDE-10 `/help`** — søkbar FAQ + kjente feilløsninger lagret som markdown-filer

I tillegg: `/glossary` tracker nå `view_glossary`-events slik at onboarding-steg 3 fra GUIDE-1 markeres automatisk.

## GUIDE-3: Visuell plattform-oversikt
- Mermaid `flowchart LR` viser: `Kafka → IDP → Bronze → Airflow → Silver → Gold → Jupyter/Superset`, med portalen som styringspunkt på siden
- Hver node er klikkbar — åpner Bootstrap-modal med kort forklaring og lenke til glossaret når relevant
- Lag-fargekoding samsvarer med Bronze/Silver/Gold-merkene ellers i UI
- Ekstra ressurs-grid med direkte glossar-lenker for de viktigste konseptene

## GUIDE-10: FAQ og kjente feilløsninger
- 10 FAQ + 5 troubleshoot-entries i kategoriserte accordions med søkbart filter
- Innhold som markdown med YAML-frontmatter i `dataportal/help/`:

```
---
title: Hvordan ber jeg om tilgang til et restricted produkt?
category: faq
slug: request-access
---
Restricted produkter krever eksplisitt godkjenning…
```

- `dataportal/help_content.py` parser frontmatter, rendrer markdown-body via `markdown==3.7` (ny avhengighet) og cacher på første kall
- Plattformteamet kan oppdatere uten kodeendringer
- URL-anker `/help#<slug>` ekspanderer riktig accordion-element

### Initialt innhold
**FAQ**: hvor finner jeg eier, hvordan be om tilgang, Bronze vs Silver vs Gold, publisering, abonnement, PII-maskering, SLA-brudd, Jupyter-credentials, Superset-bruk, schema-kompatibilitet.

**Troubleshoot**: OOMKill, 401 fra portal-API, MinIO-konnektivitet fra Jupyter, Spark 403, tom Silver-tabell (siste basert på residence_history-bug fra april — vi har en konkret incident-erfaring i FAQ-en).

## Sidebar
Ny "Hjelp"-seksjon med tre lenker:
- **Hvordan det fungerer** (GUIDE-3)
- **Glossar** (eksisterende)
- **Hjelp og FAQ** (GUIDE-10)

## Ny avhengighet
`markdown==3.7` lagt til i `docker/dataportal/requirements.txt`. Krever rebuild av image.

## Verifisert
- `GET /how-it-works` → 200 OK på 70 ms
- `GET /help` → 200 OK på 91 ms med alle 15 entries rendret
- Søkefilter på `/help` filtrerer entries i sanntid
- Mermaid-graf rendrer og noder er klikkbare

## Closes
Closes #126, #133

## Test plan
- [ ] Åpne `/how-it-works` og klikk på hver node — modal viser forklaring og glossar-lenke der relevant
- [ ] Åpne `/help` og søk etter "OOM" — kun relevante entries vises
- [ ] Naviger direkte til `/help#sla-breach` — riktig entry ekspanderes
- [ ] Verifiser at `/glossary` tracker `view_glossary` (innlogget bruker → onboarding-steg 3 oppdateres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)