### PR TITLE
feat(portal,minio): silver-config-lagring i MinIO med versjonering (SILVER-3)

### DIFF
--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -1710,7 +1710,7 @@ _PIPELINE_TEMPLATES = {
         "tags":        ["transform", "silver"],
         "fields": [
             {"name": "dag_id",       "label": "DAG-ID",           "type": "text",   "placeholder": "mitt_silver_transform", "required": True},
-            {"name": "config_path",  "label": "Konfig-sti",       "type": "text",   "placeholder": "/opt/airflow/spark_conf/silver/domene/tabell.json", "required": True},
+            {"name": "config_path",  "label": "Konfig-sti",       "type": "text",   "placeholder": "s3a://config/silver/<slug>/current.json eller lokal sti", "required": True},
             {"name": "domain",       "label": "Domene",           "type": "text",   "placeholder": "hr", "required": True},
             {"name": "owner",        "label": "Eier",             "type": "text",   "placeholder": "teamet-ditt", "required": True},
             {"name": "schedule",     "label": "Kjøreplan",        "type": "select", "options": ["@daily","@weekly","@monthly","None"], "required": True},
@@ -2270,6 +2270,58 @@ def _save_pipeline_config(dag_id: str, template_id: str, config: dict) -> None:
     )
 
 
+def _save_silver_config(slug: str, config: dict) -> str:
+    """SILVER-3: lagre silver-config-JSON i s3://config/silver/{slug}/.
+
+    Returnerer s3a://-URL-en til current.json. Versjon legges også til
+    history.json (samme mønster som _save_pipeline_config — maks 10).
+    """
+    s3 = _s3_client()
+    now     = datetime.now(tz=timezone.utc).isoformat()
+    payload = {"slug": slug, "config": config, "saved_at": now}
+    s3.put_object(
+        Bucket="config",
+        Key=f"silver/{slug}/current.json",
+        Body=json.dumps(payload, indent=2).encode(),
+        ContentType="application/json",
+    )
+    history: list[dict] = []
+    try:
+        obj = s3.get_object(Bucket="config", Key=f"silver/{slug}/history.json")
+        history = json.loads(obj["Body"].read())
+    except ClientError:
+        pass
+    history.insert(0, payload)
+    history = history[:10]
+    s3.put_object(
+        Bucket="config",
+        Key=f"silver/{slug}/history.json",
+        Body=json.dumps(history, indent=2).encode(),
+        ContentType="application/json",
+    )
+    return f"s3a://config/silver/{slug}/current.json"
+
+
+def _load_silver_config(slug: str) -> dict | None:
+    """SILVER-3: hent gjeldende silver-config fra MinIO."""
+    try:
+        s3  = _s3_client()
+        obj = s3.get_object(Bucket="config", Key=f"silver/{slug}/current.json")
+        return json.loads(obj["Body"].read())
+    except ClientError:
+        return None
+
+
+def _load_silver_config_history(slug: str) -> list[dict]:
+    """SILVER-3: hent versjonshistorikk for en silver-config."""
+    try:
+        s3  = _s3_client()
+        obj = s3.get_object(Bucket="config", Key=f"silver/{slug}/history.json")
+        return json.loads(obj["Body"].read())
+    except ClientError:
+        return []
+
+
 def _load_pipeline_config(dag_id: str) -> dict | None:
     """Last gjeldende pipeline-konfigurasjon fra MinIO."""
     try:
@@ -2751,6 +2803,21 @@ def api_get_pipeline_config(dag_id: str):
     current = _load_pipeline_config(dag_id)
     history = _load_pipeline_history(dag_id)
     return {"current": current, "history": history}
+
+
+@app.get("/api/silver/configs/{slug}", tags=["pipelines"], summary="Hent gjeldende silver-config")
+def api_get_silver_config(slug: str):
+    """SILVER-3: gjeldende silver-config-payload fra s3://config/silver/{slug}/current.json."""
+    current = _load_silver_config(slug)
+    if current is None:
+        raise HTTPException(status_code=404, detail=f"Ingen silver-config funnet for slug='{slug}'")
+    return current
+
+
+@app.get("/api/silver/configs/{slug}/history", tags=["pipelines"], summary="Hent silver-config-historikk")
+def api_get_silver_config_history(slug: str):
+    """SILVER-3: historikk (maks 10 versjoner) for en silver-config."""
+    return {"slug": slug, "history": _load_silver_config_history(slug)}
 
 
 @app.get("/api/pipelines/{dag_id}/status", tags=["pipelines"], summary="Hent Airflow-status for DAG")

--- a/jobs/transform_bronze_to_silver.py
+++ b/jobs/transform_bronze_to_silver.py
@@ -219,12 +219,33 @@ def run(spark: SparkSession, config: dict) -> None:
     })
 
 
+def _load_config(path: str) -> dict:
+    """Les config-JSON fra lokal sti eller S3/S3A (SILVER-3)."""
+    if path.startswith(("s3://", "s3a://")):
+        import os
+        import boto3
+        from botocore.client import Config as BotoConfig
+        # s3:// og s3a:// behandles likt — det er bucket+key
+        no_scheme = path.split("://", 1)[1]
+        bucket, key = no_scheme.split("/", 1)
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=os.environ.get("AWS_ENDPOINT_URL", "http://minio.slettix-analytics.svc.cluster.local:9000"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "admin"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "changeme"),
+            config=BotoConfig(signature_version="s3v4"),
+        )
+        body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+        return json.loads(body)
+    return json.loads(Path(path).read_text())
+
+
 def main():
     parser = argparse.ArgumentParser(description="Bronze → Silver transformation")
-    parser.add_argument("--config", required=True, help="Path to silver config JSON")
+    parser.add_argument("--config", required=True, help="Path to silver config JSON (lokal eller s3a://)")
     args = parser.parse_args()
 
-    config = json.loads(Path(args.config).read_text())
+    config = _load_config(args.config)
 
     spark = (
         SparkSession.builder

--- a/k8s/helm/minio/bucket-init-job.yaml
+++ b/k8s/helm/minio/bucket-init-job.yaml
@@ -78,5 +78,10 @@ spec:
               echo "Oppretter stream-input-mappe..."
               mc cp /dev/null local/raw/stream-input/.domain
 
+              # SILVER-3: config-bucket for pipeline-konfigurasjoner
+              echo "Oppretter config-bucket..."
+              mc mb --ignore-existing local/config
+              mc cp /dev/null local/config/silver/.keep
+
               echo "Mappe-struktur klar."
               mc ls local/

--- a/k8s/helm/minio/values.yaml
+++ b/k8s/helm/minio/values.yaml
@@ -47,6 +47,9 @@ buckets:
   - name: analytics
     policy: none
     purge: false
+  - name: config
+    policy: none
+    purge: false
 
 # ── Ressurser (tilpasset lokal Docker Desktop) ────────────────────────────────
 # PERF-7: hevet fra 256Mi/512Mi → 512Mi/1Gi for å håndtere parallelle kall fra


### PR DESCRIPTION
## Summary
Lagrer Silver-config-JSON i MinIO med versjonshistorikk. Forutsetning for SILVER-5 (deploy-endepunkt) som binder hele Silver-wizarden sammen.

## Endringer
- **Ny `config`-bucket** i MinIO (`bucket-init-job.yaml` + `values.yaml`)
- **Struktur**: `s3://config/silver/{slug}/current.json` og `.../history.json` — samme mønster som eksisterende `pipeline_configs/`
- **Tre helpers** i `dataportal/main.py`:
    - `_save_silver_config(slug, config)` → skriver current + appender til history (maks 10 versjoner). Returnerer `s3a://`-URL
    - `_load_silver_config(slug)` → leser current
    - `_load_silver_config_history(slug)` → leser history
- **GET-endepunkter**:
    - `/api/silver/configs/{slug}` → 200 m/ payload eller 404 hvis ingen config
    - `/api/silver/configs/{slug}/history` → `{slug, history[]}`
- **`jobs/transform_bronze_to_silver.py`** utvidet med `_load_config()` som støtter både lokal sti og `s3://`/`s3a://`. Bakoverkompatibel
- **`silver_transform`-malen** i Pipeline Builder oppdatert med ny placeholder: `s3a://config/silver/<slug>/current.json`

## Verifisert ende-til-ende
```
$ _save_silver_config('test-silver', {...})
Lagret: s3a://config/silver/test-silver/current.json

$ _save_silver_config('test-silver', {...v2...})
Historikk-versjoner: 2

$ curl /api/silver/configs/test-silver
{ "slug": "test-silver", "config": {...v2...}, "saved_at": "..." }

$ curl /api/silver/configs/test-silver/history
{ "slug": "test-silver", "history": [v2, v1] }
```

## Test plan
- [ ] Verifiser at `mc ls local/` viser den nye `config`-bucketen etter rerun av bucket-init-job
- [ ] Skriv en silver-config via `_save_silver_config()` og verifiser `current.json` + `history.json` i MinIO Console
- [ ] Skriv en v2 → historikk-listen har 2 versjoner i riktig rekkefølge
- [ ] `GET /api/silver/configs/nonexistent` → 404
- [ ] Kjør `transform_bronze_to_silver.py --config s3a://config/silver/test/current.json` (manuell test fra Spark-pod) — bekreft at config leses

## Closes
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)