### PR TITLE
feat(portal): auto-rollout-restart av Airflow scheduler (#144)

### DIFF
--- a/k8s/apps/dataportal/rbac.yaml
+++ b/k8s/apps/dataportal/rbac.yaml
@@ -11,6 +11,10 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["airflow-dags"]
     verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["airflow-scheduler", "airflow-webserver"]
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Lukker #144.

## Summary

Etter at en ny DAG patches inn i `airflow-dags` ConfigMap, blir den ikke synlig før init-container kjører på neste pod-start. Denne PR-en lar dataportalen automatisk trigge `kubectl rollout restart`-ekvivalent på `airflow-scheduler` rett etter ConfigMap-patch, slik at analytikere som deployer fra UI får DAG-en aktiv umiddelbart.

Endepunkter berørt:
* `POST /api/pipelines` (create_pipeline)
* `PUT  /api/pipelines/{dag_id}` (update_pipeline)
* `POST /api/wizard/silver/deploy` (silver-wizardens deploy-flow)

Alle returnerer nå `scheduler_restart_status` i tillegg til `configmap_status`.

## Test plan

- [ ] Deploy en pipeline via /pipeline-builder UI; bekreft at den blir synlig i Airflow innen ~20-30s uten manuell restart
- [ ] Deploy via Silver-wizarden; verifiser at `scheduler_restart_status: "ok"` returneres
- [ ] Force-fail ConfigMap-patch (f.eks. ved å fjerne RBAC midlertidig): verifiser at scheduler_restart_status = "skipped (cm-patch feilet)" og endepunktet ikke krasjer
- [ ] Verifiser at `kubectl describe deployment airflow-scheduler` viser ny `restartedAt`-annotation etter deploy

## Akseptansekriterier (fra issue)

- [x] Rollout-restart trigges via `restartedAt`-annotation
- [x] `scheduler_restart_status` returneres
- [x] Best-effort (feiler ikke hovedendepunktet)
- [x] RBAC utvidet med `deployments[airflow-scheduler,airflow-webserver]/get,patch`
- [x] Webserver-mulighet: RBAC åpnet for både scheduler og webserver, men kun scheduler restartes per nå (webserver poller scheduler — UI oppdateres innen ~30s uansett)

🤖 Generated with [Claude Code](https://claude.com/claude-code)