### PR TITLE
feat(portal): auto-default persona basert på domeneprivilegier (#127)

### DIFF
--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -4169,6 +4169,16 @@ def page_catalog(request: Request):
     view_counts = {r["product_id"]: r["views"] for r in auth.get_usage_counts(30)}
 
     # GUIDE-4: rolle-tilpassede landings­widgets — påvirkes av ?persona=… for toggle.
+    # Auto-default ved første besøk: hvis brukeren ikke har persona satt, utled fra
+    # domeneprivilegier (admin/domeneeier → domain_owner, andre → analyst) og persist.
+    if user and not user.get("persona") and not request.query_params.get("persona"):
+        if user.get("role") == "admin" or auth.get_user_domains(user["id"]):
+            default_persona = "domain_owner"
+        else:
+            default_persona = "analyst"
+        auth.set_persona(user["id"], default_persona)
+        user["persona"] = default_persona
+
     persona  = (request.query_params.get("persona") or (user or {}).get("persona") or "analyst")
     if persona not in auth.PERSONAS:
         persona = "analyst"


### PR DESCRIPTION
Lukker #127, dermed siste user story i epic #123 (Veivisning og selvbetjening for analytikere).

## Bakgrunn

Akseptansekriterier for GUIDE-4 var nesten alle oppfylt fra før:
- ✅ Persona-kolonne i auth.db
- ✅ Rolle-tilpasset landing via `_persona_landing()`
- ✅ Toggle i header (dropdown med `?persona=...`)
- ⏳ **Manglet:** Auto-default basert på domeneprivilegier ved første besøk

## Endring

På `/`-endepunktet: hvis innlogget bruker ikke har persona satt (og ikke har valgt via toggle), utled persona og persistér:
- `admin` eller bruker med domeneprivilegier → `domain_owner`
- alle andre → `analyst`

Toggle (`?persona=…`) overstyrer fortsatt for ad-hoc-bytte uten å endre standardvalget.

## Test plan

- [ ] Ny bruker uten domeneprivilegier logger inn → `/` viser analytiker-vista
- [ ] Bruker tildelt domain-privileg via admin → første besøk på `/` setter `domain_owner`
- [ ] Toggle i header endrer vista uten å overskrive persisted persona
- [ ] Verifiser at persona persisteres i auth.db (overlever pod-restart)

Med denne lukkes epic #123 (10/10 user stories ferdig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)