### PR TITLE
fix(helse): schedule DAR-pipelinene til 05/06 UTC + DNS-1123-fiks i silver_transform-mal

### DIFF
--- a/airflow/dags/helse_dar_gold.py
+++ b/airflow/dags/helse_dar_gold.py
@@ -120,7 +120,9 @@ default_args = {
 with DAG(
     dag_id="helse_dar_gold",
     description="DAR Gold: denormalisert dødsfall_enriched + medvirkende-bridge, beriket med ICD-10",
-    schedule="@daily",
+    # Kjøres kl 06:00 UTC — etter helse_dar (Silver, 05:00) som er etter
+    # folkeregister_silver (02:00) — gir tid til at oppstrømsdata er klar.
+    schedule="0 6 * * *",
     start_date=datetime(2024, 1, 15),
     catchup=False,
     default_args=default_args,

--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -1932,6 +1932,9 @@ def _fetch_api(**context):
 
     elif template_id == "silver_transform":
         config_path = config.get("config_path", "/opt/airflow/spark_conf/silver/data.json")
+        # K8s metadata.name må følge DNS-1123 — kun [a-z0-9-]. dag_id kan
+        # inneholde understrek (gyldig i Airflow), så vi saniterer for CRD-navn.
+        spark_app_name = re.sub(r"[^a-z0-9-]", "-", dag_id.lower())[:50]
         # SparkKubernetesOperator i stedet for SparkSubmitOperator — spawner egen
         # Spark-driver/executor-pod med slettix-analytics/spark:3.5.8-image som
         # har Delta/Hadoop/S3A-JARs bakt inn. Unngår OOM på Airflow-worker-pod.
@@ -1939,7 +1942,7 @@ def _fetch_api(**context):
 apiVersion: sparkoperator.k8s.io/v1beta2
 kind: SparkApplication
 metadata:
-  name: {dag_id}-{{{{ ds_nodash }}}}
+  name: {spark_app_name}-{{{{ ds_nodash }}}}
   namespace: slettix-analytics
 spec:
   type: Python
@@ -1986,7 +1989,7 @@ spec:
     - name: jobs
       configMap:
         name: airflow-jobs
-'''.format(dag_id=dag_id, config_path=config_path)
+'''.format(spark_app_name=spark_app_name, config_path=config_path)
         body = f'''from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import SparkKubernetesOperator
 
 _SPARK_APP = """{spark_app}"""


### PR DESCRIPTION
## Summary

* `helse_dar` flyttes fra @daily (midnatt) til **0 5 * * *** — gir folkeregister_silver (02:00) god margin
* `helse_dar_gold` flyttes fra @daily til **0 6 * * *** — kjøres etter helse_dar Silver er klar
* **Bonus-fiks**: silver_transform-malen sanitiserer nå dag_id til DNS-1123-kompatibelt SparkApp-navn (oppdaget under regenerering av helse_dar — wizard-genererte DAGs med understrek i dag_id ville feile metadata-validering)

## Hvordan endringene ble deployet

* helse_dar (wizard-generert): regenerert via `_generate_dag_from_template` + `_patch_dag_configmap` + auto-restart
* helse_dar_gold (repo-fil): redigert, deployet via `k8s-update-configmaps.sh dags`
* Begge schedules verifisert mot live scheduler — next_dagrun viser 05:00 / 06:00

## Test plan

- [ ] Verifiser i Airflow UI: helse_dar og helse_dar_gold viser nye cron-strenger
- [ ] Vent til 05:00/06:00 UTC og sjekk at scheduled runs starter på riktig tidspunkt
- [ ] Verifiser at SparkApplication-CRD-er får DNS-1123-gyldige navn (bindestrek, ikke understrek)

🤖 Generated with [Claude Code](https://claude.com/claude-code)