### PR TITLE
fix(silver-wizard): regressjonsfiks for transform_bronze_to_silver + labels

### DIFF
--- a/dataportal/main.py
+++ b/dataportal/main.py
@@ -1970,6 +1970,8 @@ spec:
     memory: "1g"
     memoryOverhead: "256m"
     serviceAccount: spark
+    labels:
+      version: "3.5.8"
     env:
       - {{name: AWS_ACCESS_KEY_ID, valueFrom: {{secretKeyRef: {{name: slettix-credentials, key: minio-root-user}}}}}}
       - {{name: AWS_SECRET_ACCESS_KEY, valueFrom: {{secretKeyRef: {{name: slettix-credentials, key: minio-root-password}}}}}}
@@ -1980,6 +1982,8 @@ spec:
     cores: 1
     memory: "1g"
     memoryOverhead: "256m"
+    labels:
+      version: "3.5.8"
     env:
       - {{name: AWS_ACCESS_KEY_ID, valueFrom: {{secretKeyRef: {{name: slettix-credentials, key: minio-root-user}}}}}}
       - {{name: AWS_SECRET_ACCESS_KEY, valueFrom: {{secretKeyRef: {{name: slettix-credentials, key: minio-root-password}}}}}}

--- a/jobs/transform_bronze_to_silver.py
+++ b/jobs/transform_bronze_to_silver.py
@@ -219,25 +219,42 @@ def run(spark: SparkSession, config: dict) -> None:
     })
 
 
-def _load_config(path: str) -> dict:
-    """Les config-JSON fra lokal sti eller S3/S3A (SILVER-3)."""
+def _load_config(path: str, spark: SparkSession | None = None) -> dict:
+    """Les config-JSON fra lokal sti eller S3/S3A (SILVER-3).
+
+    For s3://-stier brukes Spark sin egen `wholeTextFiles`-reader, som
+    arver s3a-konfigen fra SparkSession. Det unngår avhengighet til
+    boto3 i Spark-imaget.
+
+    Wizardens deploy lagrer payloaden som
+    `{slug, config: {...}, saved_at}` — funksjonen pakker ut `config`
+    så den faktiske transformasjons-configen returneres uansett format.
+    """
     if path.startswith(("s3://", "s3a://")):
-        import os
-        import boto3
-        from botocore.client import Config as BotoConfig
-        # s3:// og s3a:// behandles likt — det er bucket+key
-        no_scheme = path.split("://", 1)[1]
-        bucket, key = no_scheme.split("/", 1)
-        s3 = boto3.client(
-            "s3",
-            endpoint_url=os.environ.get("AWS_ENDPOINT_URL", "http://minio.slettix-analytics.svc.cluster.local:9000"),
-            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", "admin"),
-            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", "changeme"),
-            config=BotoConfig(signature_version="s3v4"),
-        )
-        body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
-        return json.loads(body)
-    return json.loads(Path(path).read_text())
+        s3a_path = path.replace("s3://", "s3a://", 1)
+        if spark is None:
+            spark = SparkSession.builder.getOrCreate()
+        rdd = spark.sparkContext.wholeTextFiles(s3a_path)
+        contents = rdd.collect()
+        if not contents:
+            raise FileNotFoundError(f"Fant ikke config-fil på {s3a_path}")
+        raw = json.loads(contents[0][1])
+    else:
+        raw = json.loads(Path(path).read_text())
+
+    if isinstance(raw, dict) and "source" not in raw and isinstance(raw.get("config"), dict):
+        cfg = raw["config"]
+    else:
+        cfg = raw
+
+    # Spark s3a-driveren registreres bare for `s3a://`. Normaliserer eldre
+    # configs som bruker `s3://` for source/target slik at Delta-leseren
+    # finner riktig FileSystem-impl.
+    for key in ("source", "target"):
+        val = cfg.get(key)
+        if isinstance(val, str) and val.startswith("s3://"):
+            cfg[key] = val.replace("s3://", "s3a://", 1)
+    return cfg
 
 
 def main():
@@ -245,14 +262,16 @@ def main():
     parser.add_argument("--config", required=True, help="Path to silver config JSON (lokal eller s3a://)")
     args = parser.parse_args()
 
-    config = _load_config(args.config)
-
+    # SparkSession opprettes først — _load_config trenger den for å lese
+    # s3a://-stier via Spark sin egen reader.
     spark = (
         SparkSession.builder
-        .appName(f"bronze_to_silver:{config['target'].split('/')[-1]}")
+        .appName("bronze_to_silver")
         .getOrCreate()
     )
     spark.sparkContext.setLogLevel("WARN")
+
+    config = _load_config(args.config, spark=spark)
 
     run(spark, config)
     spark.stop()


### PR DESCRIPTION
## Bakgrunn

Den schedulerte helse_dar-kjøringen kl 05:00 UTC i dag (første run på den nye 05:00-tiden satt i PR #161) feilet på `bronze_to_silver`-tasken. Diagnostikk avdekket to regresjoner som har sneket seg inn — begge ble opprinnelig fikset i tidligere arbeid på fix/silver-transform-spark-operator-branchen, men den branchen ble aldri merget ren mot main.

## Endringer

### 1) `jobs/transform_bronze_to_silver.py` — `_load_config` og `main()`
- Bytter fra `boto3` (mangler i Spark-imaget — gir `ModuleNotFoundError: No module named 'boto3'`) til Spark sin egen `wholeTextFiles`-reader som arver s3a-konfigurasjonen
- Pakker ut wizardens `{slug, config, saved_at}`-wrapper automatisk
- Normaliserer `s3://` → `s3a://` for source/target (kun s3a er registrert som FileSystem-impl)
- `main()` oppretter SparkSession FØR config lastes (kreves av wholeTextFiles)

### 2) `dataportal/main.py` — silver_transform-mal
- SparkKubernetesOperator-operatøren krever `labels`-felt på driver og executor; uten det får SparkApplication-CRD-en `KeyError: 'labels'` og task feiler umiddelbart
- Legger til `labels: { version: "3.5.8" }` på begge

## Verifisering

Etter deploy:
```
bronze_to_silver | success | 50s | manual trigger på regenerert DAG
```

Trigget ny manual-run mot regenerert helse_dar.py — `bronze_to_silver`-task gikk grønt etter 50 sek. Klar for neste schedulerte run i morgen kl 05:00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)